### PR TITLE
Refactor exif_writer.py for improved clarity and efficiency

### DIFF
--- a/src/google_takeout_metadata/exif_writer.py
+++ b/src/google_takeout_metadata/exif_writer.py
@@ -6,7 +6,7 @@ from typing import List
 
 from .sidecar import SidecarData
 
-VIDEO_EXTS = {".mp4", ".mov", ".m4v", ".3gp"}  # un peu plus large
+VIDEO_EXTS = {".mp4", ".mov", ".m4v", ".3gp"}  # broader set of video extensions
 
 def _is_video_file(path: Path) -> bool:
     return path.suffix.lower() in VIDEO_EXTS

--- a/src/google_takeout_metadata/exif_writer.py
+++ b/src/google_takeout_metadata/exif_writer.py
@@ -1,150 +1,101 @@
-"""Write metadata to images using the external ``exiftool`` utility."""
-
-from __future__ import annotations
-
+# imports: supprime import shlex, tempfile
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
-import shlex
-import subprocess
-import tempfile
 
 from .sidecar import SidecarData
 
+VIDEO_EXTS = {".mp4", ".mov", ".m4v", ".3gp"}  # un peu plus large
 
 def _is_video_file(path: Path) -> bool:
-    """Check if the file is a video file based on extension."""
-    return path.suffix.lower() in {".mp4", ".mov"}
+    return path.suffix.lower() in VIDEO_EXTS
 
+def _fmt_dt(ts: int | None, use_localtime: bool) -> str | None:
+    if ts is None:
+        return None
+    dt = datetime.fromtimestamp(ts) if use_localtime else datetime.fromtimestamp(ts, tz=timezone.utc)
+    return dt.strftime("%Y:%m:%d %H:%M:%S")  # EXIF sans fuseau
 
 def build_exiftool_args(meta: SidecarData, image_path: Path | None = None, use_localtime: bool = False) -> List[str]:
-    """Return a list of arguments for ``exiftool`` based on ``meta``."""
-
     args: List[str] = []
 
-    # Add charset parameters for Unicode/accent support
-    args.extend([
+    # Charsets pour Unicode/accents
+    args += [
         "-charset", "filename=UTF8",
-        "-charset", "iptc=UTF8", 
+        "-charset", "iptc=UTF8",
         "-charset", "exif=UTF8",
         "-charset", "XMP=UTF8",
-    ])
-    
-    # Add QuickTime UTC API option for video files
+    ]
+
+    # Vidéos : clarifier que nos timestamps source sont en UTC quand use_localtime=False
     if image_path and _is_video_file(image_path):
-        args.extend(["-api", "QuickTimeUTC=1"])
+        args += ["-api", "QuickTimeUTC=1"]
 
+    # Description
     if meta.description:
-        # Quote the description to handle spaces and special characters
-        quoted_desc = shlex.quote(meta.description)
-        args.extend(
-            [
-                f"-EXIF:ImageDescription={quoted_desc}",
-                f"-XMP-dc:Description={quoted_desc}",
-                f"-IPTC:Caption-Abstract={quoted_desc}",
-            ]
-        )
-        # Add video-specific title/description tags if it's a video file
+        args += [
+            f"-EXIF:ImageDescription={meta.description}",
+            f"-XMP-dc:Description={meta.description}",
+            f"-IPTC:Caption-Abstract={meta.description}",
+        ]
         if image_path and _is_video_file(image_path):
-            args.extend([
-                f"-Keys:Title={quoted_desc}",
-                f"-Keys:Description={quoted_desc}",
-            ])
+            # Pour le moment, pas de "title" textuel distinct → on évite Keys:Title = description
+            args += [f"-Keys:Description={meta.description}"]
 
+    # Personnes
     for person in meta.people:
-        # Quote person names to handle spaces and special characters
-        quoted_person = shlex.quote(person)
-        args.extend(
-            [
-                f"-XMP-iptcExt:PersonInImage+={quoted_person}",
-                f"-XMP-dc:Subject+={quoted_person}",
-                f"-IPTC:Keywords+={quoted_person}",
-            ]
-        )
+        args += [
+            f"-XMP-iptcExt:PersonInImage+={person}",
+            f"-XMP-dc:Subject+={person}",
+            f"-IPTC:Keywords+={person}",
+        ]
 
-    if meta.taken_at is not None:
-        if use_localtime:
-            dt = datetime.fromtimestamp(meta.taken_at)  # local time
-        else:
-            dt = datetime.fromtimestamp(meta.taken_at, tz=timezone.utc)
-        formatted = dt.strftime("%Y:%m:%d %H:%M:%S")
-        # Quote datetime to handle spaces
-        quoted_datetime = shlex.quote(formatted)
-        args.append(f"-DateTimeOriginal={quoted_datetime}")
-
+    # Dates EXIF
+    if (s := _fmt_dt(meta.taken_at, use_localtime)):
+        args.append(f"-DateTimeOriginal={s}")
     base_ts = meta.created_at or meta.taken_at
-    if base_ts is not None:
-        if use_localtime:
-            dt = datetime.fromtimestamp(base_ts)  # local time
-        else:
-            dt = datetime.fromtimestamp(base_ts, tz=timezone.utc)
-        formatted = dt.strftime("%Y:%m:%d %H:%M:%S")
-        # Quote datetime to handle spaces
-        quoted_datetime = shlex.quote(formatted)
-        args.extend([f"-CreateDate={quoted_datetime}", f"-ModifyDate={quoted_datetime}"])
-        
-        # Add video-specific date tags if it's a video file
-        if image_path and _is_video_file(image_path):
-            args.extend([
-                f"-QuickTime:CreateDate={quoted_datetime}",
-                f"-QuickTime:ModifyDate={quoted_datetime}",
-            ])
+    if (s := _fmt_dt(base_ts, use_localtime)):
+        args += [f"-CreateDate={s}", f"-ModifyDate={s}"]
 
+    # Dates QuickTime (vidéos)
+    if image_path and _is_video_file(image_path):
+        if (s := _fmt_dt(meta.taken_at, use_localtime)):
+            args += [f"-QuickTime:CreateDate={s}"]
+        if (s := _fmt_dt(base_ts, use_localtime)):
+            args += [f"-QuickTime:ModifyDate={s}"]
+
+    # GPS
     if meta.latitude is not None and meta.longitude is not None:
         lat_ref = "N" if meta.latitude >= 0 else "S"
         lon_ref = "E" if meta.longitude >= 0 else "W"
-        args.extend(
-            [
-                f"-GPSLatitude={abs(meta.latitude)}",
-                f"-GPSLatitudeRef={lat_ref}",
-                f"-GPSLongitude={abs(meta.longitude)}",
-                f"-GPSLongitudeRef={lon_ref}",
-            ]
-        )
+        args += [
+            f"-GPSLatitude={abs(meta.latitude)}",
+            f"-GPSLatitudeRef={lat_ref}",
+            f"-GPSLongitude={abs(meta.longitude)}",
+            f"-GPSLongitudeRef={lon_ref}",
+        ]
         if meta.altitude is not None:
             alt_ref = "1" if meta.altitude < 0 else "0"
-            args.extend(
-                [
-                    f"-GPSAltitude={abs(meta.altitude)}",
-                    f"-GPSAltitudeRef={alt_ref}",
-                ]
-            )
-        
-        # Add video-specific GPS tags if it's a video file
+            args += [f"-GPSAltitude={abs(meta.altitude)}", f"-GPSAltitudeRef={alt_ref}"]
+
         if image_path and _is_video_file(image_path):
-            args.extend([
-                f"-Keys:Location={meta.latitude},{meta.longitude}",
-                f"-QuickTime:GPSCoordinates={meta.latitude},{meta.longitude}",
-            ])
+            # QuickTime:GPSCoordinates accepte "lat lon" ou "lat,lon" selon les players ; cette forme marche en général
+            args += [f"-QuickTime:GPSCoordinates={meta.latitude},{meta.longitude}"]
+            # Keys:Location est peu standardisé ; garde-le si ça t’aide dans ton écosystème
+            args += [f"-Keys:Location={meta.latitude},{meta.longitude}"]
 
     return args
 
-
 def write_metadata(image_path: Path, meta: SidecarData, use_localtime: bool = False) -> None:
-    """Write ``meta`` into ``image_path``.
-
-    Raises
-    ------
-    RuntimeError
-        If ``exiftool`` exits with a non-zero status.
-    """
-
     args = build_exiftool_args(meta, image_path, use_localtime=use_localtime)
     if not args:
         return
 
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as fh:
-        fh.write("\n".join(args))
-        arg_path = fh.name
-    cmd = ["exiftool", "-overwrite_original", "-@", arg_path, str(image_path)]
+    cmd = ["exiftool", "-overwrite_original", *args, str(image_path)]
     try:
         subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
-    except FileNotFoundError as exc:  # pragma: no cover - depends on system
-        ...
+    except FileNotFoundError as exc:
         raise RuntimeError("exiftool not found") from exc
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"exiftool failed for {image_path}: {exc.stderr or exc.stdout}"
-        ) from exc
-    finally:
-        Path(arg_path).unlink(missing_ok=True)
+        raise RuntimeError(f"exiftool failed for {image_path}: {exc.stderr or exc.stdout}") from exc

--- a/src/google_takeout_metadata/exif_writer.py
+++ b/src/google_takeout_metadata/exif_writer.py
@@ -51,7 +51,9 @@ def build_exiftool_args(meta: SidecarData, image_path: Path | None = None, use_l
             f"-IPTC:Keywords+={person}",
         ]
 
-    # Dates EXIF
+    # Set standard EXIF date fields:
+    # - DateTimeOriginal is set from meta.taken_at (when the photo/video was taken)
+    # - CreateDate and ModifyDate are set from meta.created_at if available, otherwise from meta.taken_at
     if (s := _fmt_dt(meta.taken_at, use_localtime)):
         args.append(f"-DateTimeOriginal={s}")
     base_ts = meta.created_at or meta.taken_at


### PR DESCRIPTION
This pull request refactors the `exif_writer.py` module to simplify the code, improve maintainability, and enhance support for video file metadata. The main improvements are the removal of unnecessary imports and quoting logic, streamlined argument construction for `exiftool`, and expanded support for video formats and metadata tags.

**Refactoring and simplification:**
- Removed unused imports (`shlex`, `tempfile`) and all quoting logic, as arguments are now passed directly to `exiftool` without the need for shell quoting. (`[src/google_takeout_metadata/exif_writer.pyL1-R101](diffhunk://#diff-10b260de5c6de297b917c2f8e59e584f55a5a197c87c284563510a86af7f7144L1-R101)`)
- Replaced the use of a temporary file for passing arguments to `exiftool` with direct argument passing, simplifying the `write_metadata` function. (`[src/google_takeout_metadata/exif_writer.pyL1-R101](diffhunk://#diff-10b260de5c6de297b917c2f8e59e584f55a5a197c87c284563510a86af7f7144L1-R101)`)

**Enhanced video support:**
- Broadened the set of recognized video file extensions by introducing the `VIDEO_EXTS` set and updating `_is_video_file` accordingly. (`[src/google_takeout_metadata/exif_writer.pyL1-R101](diffhunk://#diff-10b260de5c6de297b917c2f8e59e584f55a5a197c87c284563510a86af7f7144L1-R101)`)
- Improved handling of video-specific metadata tags, such as `QuickTime:CreateDate`, `QuickTime:ModifyDate`, `QuickTime:GPSCoordinates`, and `Keys:Description`, ensuring more accurate and standard-compliant metadata for videos. (`[src/google_takeout_metadata/exif_writer.pyL1-R101](diffhunk://#diff-10b260de5c6de297b917c2f8e59e584f55a5a197c87c284563510a86af7f7144L1-R101)`)

**Metadata argument construction:**
- Centralized and simplified date formatting with the new `_fmt_dt` helper, reducing code duplication and clarifying time zone handling. (`F38ff4