### PR TITLE
docs: document Google Geocoding API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,26 @@ Ce projet permet d'incorporer les métadonnées des fichiers JSON produits par G
 
 ## Installation
 
-Prérequis: `exiftool` doit être installé et accessible dans le PATH.
+Prérequis:
+
+- `exiftool` doit être installé et accessible dans le PATH
+- Une clé API **Google Geocoding** est nécessaire pour la résolution d'adresses
 
 ```bash
 pip install -e .
+
+# Définir la clé API pour l'application
+export GOOGLE_GEOCODING_API_KEY="votre_clé_api"
 ```
+
+### Créer une clé API Google Geocoding
+
+1. Se connecter à la [Google Cloud Console](https://console.cloud.google.com/)
+2. Créer ou sélectionner un projet existant
+3. Activer l'API **Geocoding** depuis la bibliothèque d'API
+4. Aller dans **APIs & Services > Identifiants** et créer une clé API
+5. (Optionnel) Restreindre la clé pour l'API Geocoding
+6. Copier la clé générée puis la définir dans la variable d'environnement `GOOGLE_GEOCODING_API_KEY`
 
 ## Utilisation
 


### PR DESCRIPTION
## Summary
- document requirement for Google Geocoding API key and environment variable
- add step-by-step instructions to create the key via Google Cloud Console

## Testing
- `pytest tests/ -m "not integration"` *(fails: AssertionError in `test_end_to_end`)*

------
https://chatgpt.com/codex/tasks/task_e_68c222ecb9908329b821f3232986b3f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Ajout du prérequis Google Geocoding API en plus d’exiftool.
  - Nouvelle section détaillant la création et la configuration de la clé API (Google Cloud Console, activation de l’API, restrictions éventuelles).
  - Ajout d’un exemple pour définir la clé via une variable d’environnement.
  - Clarification de la section Prérequis ; les étapes d’installation et d’utilisation restent inchangées.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->