### PR TITLE
Implement reverse geocoding with caching and error handling

### DIFF
--- a/src/google_takeout_metadata/geocoding.py
+++ b/src/google_takeout_metadata/geocoding.py
@@ -99,6 +99,10 @@ def reverse_geocode(lat: float, lon: float) -> List[Dict[str, Any]]:
     except requests.RequestException as exc:
         raise RuntimeError("Erreur de requête de géocodage") from exc
 
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Erreur HTTP lors de la requête de géocodage: {response.status_code} - {response.text}"
+        )
     try:
         data = response.json(
     except json.JSONDecodeError as exc:


### PR DESCRIPTION
## Summary
- add reverse geocoding helper using Google Maps API
- cache lookups on disk and expose via package
- declare requests dependency
- store geocode cache in user cache directory instead of package path

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'exiftool')*

------
https://chatgpt.com/codex/tasks/task_e_68c2265d709083299107d483d1742a2c