### PR TITLE
Add location metadata support

### DIFF
--- a/src/google_takeout_metadata/exif_writer.py
+++ b/src/google_takeout_metadata/exif_writer.py
@@ -297,6 +297,27 @@ def build_gps_args(meta: SidecarData, is_video: bool = False) -> List[str]:
     
     return args
 
+
+def build_location_args(meta: SidecarData) -> List[str]:
+    """Construit les arguments pour la localisation (ville/pays/lieu)."""
+    args: List[str] = []
+
+    city = getattr(meta, "city", None)
+    country = getattr(meta, "country", None)
+    place_name = getattr(meta, "place_name", None)
+
+    if city:
+        args.extend([f"-XMP:City={city}", f"-IPTC:City={city}"])
+    if country:
+        args.extend([
+            f"-XMP:Country={country}",
+            f"-IPTC:Country-PrimaryLocationName={country}",
+        ])
+    if place_name:
+        args.append(f"-XMP:Location={place_name}")
+
+    return args
+
 def build_rating_args(meta: SidecarData) -> List[str]:
     """Construit les arguments pour le rating."""
     args: List[str] = []
@@ -394,6 +415,11 @@ def build_exiftool_args(meta: SidecarData, media_path: Path = None, use_localtim
         gps_args = build_gps_args(meta, is_video)
         if gps_args:
             append_only_args.extend(gps_args)
+
+        # Localisation (ville/pays/lieu)
+        location_args = build_location_args(meta)
+        if location_args:
+            append_only_args.extend(location_args)
         
         # Rating
         rating_args = build_rating_args(meta)
@@ -439,6 +465,9 @@ def build_exiftool_args(meta: SidecarData, media_path: Path = None, use_localtim
         
         # GPS
         args.extend(build_gps_args(meta, is_video))
+
+        # Localisation (ville/pays/lieu)
+        args.extend(build_location_args(meta))
         
         # Rating
         args.extend(build_rating_args(meta))

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -293,8 +293,36 @@ def test_build_args_default_behavior() -> None:
     assert "-XMP-iptcExt:PersonInImage+=Safe Person" in args
     # Le rating devrait être présent
     assert "-XMP:Rating=5" in args
-    # GPS devrait être présent  
+    # GPS devrait être présent
     assert "-GPS:GPSLatitude=48.8566" in args
+
+
+def test_build_args_location() -> None:
+    """Tester que les informations de localisation sont ajoutées lorsque disponibles."""
+    meta = SidecarData(
+        filename="a.jpg",
+        description=None,
+        people=[],
+        taken_at=None,
+        created_at=None,
+        latitude=None,
+        longitude=None,
+        altitude=None,
+        favorite=False,
+    )
+
+    # Ajouter dynamiquement les informations de localisation
+    meta.city = "Paris"
+    meta.country = "France"
+    meta.place_name = "Tour Eiffel"
+
+    args = build_exiftool_args(meta)
+
+    assert "-XMP:City=Paris" in args
+    assert "-IPTC:City=Paris" in args
+    assert "-XMP:Country=France" in args
+    assert "-IPTC:Country-PrimaryLocationName=France" in args
+    assert "-XMP:Location=Tour Eiffel" in args
 
 
 def test_build_args_overwrite_mode() -> None:


### PR DESCRIPTION
## Summary
- Add `build_location_args` to include city, country and place name metadata
- Integrate location arguments into `build_exiftool_args`
- Test location argument generation in `test_exif_writer`

## Testing
- `pytest -q` *(fails: missing written metadata in integration tests)*
- `pytest tests/test_exif_writer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c22b4517dc8329bf3d1c24cd8c7ba1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Nouvelles fonctionnalités
  - Prise en charge de la localisation dans les métadonnées EXIF : ville, pays et nom de lieu.
  - Émission des champs dans les espaces XMP et IPTC correspondants.
  - Fonctionne en modes ajout uniquement et écrasement ; appliqué uniquement lorsque les champs sont renseignés.

- Tests
  - Ajout de tests vérifiant la génération des arguments EXIF pour ville, pays et nom de lieu.
  - Ajustement mineur de formatage sans impact fonctionnel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->