### PR TITLE
feat: add location fields to sidecar

### DIFF
--- a/src/google_takeout_metadata/sidecar.py
+++ b/src/google_takeout_metadata/sidecar.py
@@ -23,6 +23,10 @@ class SidecarData:
     latitude: Optional[float]
     longitude: Optional[float]
     altitude: Optional[float]
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    place_name: Optional[str] = None
     favorite: bool = False
     lat_span: Optional[float] = None
     lon_span: Optional[float] = None
@@ -155,6 +159,10 @@ def parse_sidecar(path: Path) -> SidecarData:
         latitude=latitude,
         longitude=longitude,
         altitude=altitude,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=favorite,
         lat_span=lat_span,
         lon_span=lon_span,

--- a/tests/CORRECT_test_robust_approach.py
+++ b/tests/CORRECT_test_robust_approach.py
@@ -40,6 +40,10 @@ def test_robust_approach_no_duplicates():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False,
             albums=["Vacances"]
         )
@@ -62,6 +66,10 @@ def test_robust_approach_no_duplicates():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False,
             albums=["Vacances", "Famille"]
         )
@@ -107,6 +115,10 @@ def test_robust_approach_only_new_people():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False
         )
         write_metadata(test_image, meta1, append_only=True)
@@ -121,6 +133,10 @@ def test_robust_approach_only_new_people():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False
         )
         write_metadata(test_image, meta2, append_only=True)

--- a/tests/test_deduplication_robuste.py
+++ b/tests/test_deduplication_robuste.py
@@ -60,6 +60,10 @@ def test_remove_then_add_deduplication():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=["Vacances 2024", "test album"]
     )
@@ -104,6 +108,10 @@ def test_deduplication_consistency_between_modes():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=["vacances 2024"]
     )
@@ -143,6 +151,10 @@ def test_case_normalization_prevents_duplicates():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     
@@ -170,6 +182,10 @@ def test_special_characters_in_names():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     
@@ -193,6 +209,10 @@ def test_empty_values_handling():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=None      # None
     )

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -15,6 +15,10 @@ def test_write_metadata_error(tmp_path, monkeypatch):
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     img = tmp_path / "a.jpg"
@@ -39,6 +43,10 @@ def test_build_args_video():
         latitude=48.8566,
         longitude=2.3522,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     
@@ -66,6 +74,10 @@ def test_build_args_localtime():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
 
@@ -95,6 +107,10 @@ def test_build_args_append_only() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
 
@@ -128,6 +144,10 @@ def test_build_args_favorite() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=True,
     )
 
@@ -153,6 +173,10 @@ def test_build_args_no_favorite() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
 
@@ -171,6 +195,10 @@ def test_build_args_albums() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=["Vacances 2024", "Famille"]
     )
@@ -197,6 +225,10 @@ def test_build_args_video_append_only() -> None:
         latitude=48.8566,
         longitude=2.3522,
         altitude=35.0,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     
@@ -235,6 +267,10 @@ def test_build_args_albums_append_only() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=["Test Album"]
     )
@@ -259,6 +295,10 @@ def test_build_args_no_albums() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=[]
     )
@@ -278,6 +318,10 @@ def test_build_args_default_behavior() -> None:
         latitude=48.8566,
         longitude=2.3522,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=True,
     )
 
@@ -308,6 +352,10 @@ def test_build_args_overwrite_mode() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=True,
     )
 
@@ -338,6 +386,10 @@ def test_build_args_people_default() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
 
@@ -373,6 +425,10 @@ def test_build_args_albums_default() -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=["Vacances Été 2024", "Photos de Famille", "Événements Spéciaux"]
     )

--- a/tests/test_file_organization.py
+++ b/tests/test_file_organization.py
@@ -144,6 +144,10 @@ def test_file_organization_logic():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             archived=True
         )
         assert organizer.get_target_directory(archived_meta) == organizer.archive_dir
@@ -159,6 +163,10 @@ def test_file_organization_logic():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             trashed=True
         )
         assert organizer.get_target_directory(trashed_meta) == organizer.trash_dir
@@ -174,6 +182,10 @@ def test_file_organization_logic():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             locked=True
         )
         assert organizer.get_target_directory(locked_meta) == organizer.locked_dir
@@ -189,6 +201,10 @@ def test_file_organization_logic():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             archived=True,
             locked=True,
             trashed=True
@@ -206,6 +222,10 @@ def test_file_organization_logic():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             archived=True,
             trashed=True,
             locked=True
@@ -223,6 +243,10 @@ def test_file_organization_logic():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             archived=True,
             locked=True
         )

--- a/tests/test_get_all_keywords.py
+++ b/tests/test_get_all_keywords.py
@@ -17,6 +17,10 @@ def test_get_all_keywords_basic():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         albums=["vacances été", "photos famille"]
     )
     
@@ -78,6 +82,10 @@ def test_get_all_keywords_albums_only():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         albums=["ÉVÉNEMENTS SPÉCIAUX", "voyage 2024"]
     )
     
@@ -98,6 +106,10 @@ def test_get_all_keywords_excludes_local_folder_name():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         albums=["Vacances"],
         local_folder_name="Instagram"  # Ne doit PAS apparaître dans les keywords
     )
@@ -123,6 +135,10 @@ def test_build_people_keywords_args_uses_get_all_keywords():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         albums=["vacances"],
         local_folder_name="WhatsApp"  # Ne doit pas affecter les keywords
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -330,6 +330,10 @@ def test_default_safe_behavior(tmp_path: Path) -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=["Original Album"]
     )
@@ -394,6 +398,10 @@ def test_explicit_overwrite_behavior(tmp_path: Path) -> None:
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
         albums=[]
     )
@@ -447,6 +455,10 @@ def test_append_only_vs_overwrite_video_equivalence(tmp_path: Path) -> None:
         latitude=48.8566,
         longitude=2.3522,
         altitude=35.0,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=True,
         albums=["Test Album"]
     )

--- a/tests/test_p1_specific.py
+++ b/tests/test_p1_specific.py
@@ -28,6 +28,10 @@ def test_p1_write_metadata_conditional_args():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     

--- a/tests/test_processor_batch.py
+++ b/tests/test_processor_batch.py
@@ -433,10 +433,38 @@ def test_process_directory_batch_file_extension_fix(mock_parse_sidecar, mock_fix
     
     # Simuler parse_sidecar pour retourner des données différentes pour chaque appel
     mock_parse_sidecar.side_effect = [
-        SidecarData(filename="test.jpg", description="Original", people=[], taken_at=None, created_at=None, 
-                   latitude=None, longitude=None, altitude=None, favorite=False, albums=[]),
-        SidecarData(filename="test.jpeg", description="Fixed", people=[], taken_at=None, created_at=None,
-                   latitude=None, longitude=None, altitude=None, favorite=False, albums=[])
+        SidecarData(
+            filename="test.jpg",
+            description="Original",
+            people=[],
+            taken_at=None,
+            created_at=None,
+            latitude=None,
+            longitude=None,
+            altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
+            favorite=False,
+            albums=[],
+        ),
+        SidecarData(
+            filename="test.jpeg",
+            description="Fixed",
+            people=[],
+            taken_at=None,
+            created_at=None,
+            latitude=None,
+            longitude=None,
+            altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
+            favorite=False,
+            albums=[],
+        ),
     ]
     
     # Exécuter

--- a/tests/test_robust_approach.py
+++ b/tests/test_robust_approach.py
@@ -44,6 +44,10 @@ def test_robust_approach_no_duplicates():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False,
             albums=["Vacances"]
         )
@@ -68,6 +72,10 @@ def test_robust_approach_no_duplicates():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False,
             albums=["Vacances", "Famille"]
         )
@@ -111,6 +119,10 @@ def test_robust_approach_only_new_people():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False
         )
         write_metadata(test_image, meta1, append_only=True)
@@ -125,6 +137,10 @@ def test_robust_approach_only_new_people():
             latitude=None,
             longitude=None,
             altitude=None,
+            city=None,
+            state=None,
+            country=None,
+            place_name=None,
             favorite=False
         )
         write_metadata(test_image, meta2, append_only=True)

--- a/tests/test_wm_cg_fix.py
+++ b/tests/test_wm_cg_fix.py
@@ -34,6 +34,10 @@ def test_append_only_timestamps_without_description():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     
@@ -76,6 +80,10 @@ def test_fragile_wm_logic_eliminated():
         latitude=48.8566,
         longitude=2.3522,
         altitude=35.0,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=True,  # Rating=5
     )
     
@@ -113,6 +121,10 @@ def test_no_wm_in_overwrite_mode():
         latitude=None,
         longitude=None,
         altitude=None,
+        city=None,
+        state=None,
+        country=None,
+        place_name=None,
         favorite=False,
     )
     


### PR DESCRIPTION
## Summary
- add city, state, country, and place_name fields to SidecarData
- default new location fields to None when parsing sidecar JSON
- update tests to pass new fields

## Testing
- `pytest` *(fails: test_end_to_end, test_integration::test_write_and_read_albums, test_integration::test_default_safe_behavior, test_integration::test_append_only_vs_overwrite_video_equivalence, test_integration::test_batch_vs_normal_mode_equivalence, test_integration::test_batch_mode_with_mixed_file_types, test_processor_batch::test_process_directory_batch_single_file, test_processor_batch::test_process_directory_batch_multiple_files, test_processor_batch::test_process_directory_batch_with_albums, test_processor_batch::test_process_directory_batch_immediate_delete, test_processor_batch::test_process_directory_batch_file_extension_fix, test_integration::test_write_and_read_gps, test_integration::test_write_and_read_favorite, test_integration::test_append_only_mode, test_integration::test_datetime_formats, test_integration::test_albums_and_people_combined, test_integration::test_default_safe_behavior, test_integration::test_explicit_overwrite_behavior, test_integration::test_append_only_vs_overwrite_video_equivalence, test_integration::test_batch_vs_normal_mode_equivalence, test_integration::test_batch_mode_performance_benefit, test_integration::test_batch_mode_with_mixed_file_types, test_robust_approach::test_robust_approach_no_duplicates, test_robust_approach::test_robust_approach_only_new_people)`

------
https://chatgpt.com/codex/tasks/task_e_68c228f8df8c8329a322aa81336c1657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Nouveau
  - Prise en charge de nouveaux champs de localisation dans les métadonnées: ville, état/région, pays et nom du lieu. Champs optionnels, rétrocompatibles, ignorés s’ils sont absents.

- Tests
  - Mise à jour des jeux de tests pour inclure les nouveaux champs de localisation dans les données d’exemple, garantissant la compatibilité et l’absence de régression du comportement existant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->